### PR TITLE
Bump required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@
 #   3.6.0 - IMPORTED_TARGET argument to pkg_search_modules in FindPkgConfig.cmake
 #   3.8.0 - CXX_STANDARD 17 available
 #   3.9.0 - imported target in FindOpenMP.cmake
-cmake_minimum_required(VERSION 3.9.0)
+#   3.12.0 - Do not ignore default library search paths in pkg_search_module
+#            (see https://gitlab.kitware.com/cmake/cmake/-/merge_requests/2027)
+cmake_minimum_required(VERSION 3.12.0)
 cmake_policy(SET CMP0017 NEW) # https://cmake.org/cmake/help/v3.11/policy/CMP0017.html
 
 project(healmex CXX)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A package providing Matlab bindings to the [HEALPix][healpix] C++ package.
 
 - GCC 7+ (or a compiler which supports C++17's structured bindings)
 - Matlab R2018a+
-- CMake 3.9.0+
+- CMake 3.12.0+
 - `pkg-config` (or `pkgconf`)
 - Internet connection (to download HEALPix sources)
   - HEALPix v3.40 is used

--- a/mex/CMakeLists.txt
+++ b/mex/CMakeLists.txt
@@ -1,5 +1,5 @@
 # See parent directory for notes on version minimum
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.12.0)
 cmake_policy(SET CMP0017 NEW) # https://cmake.org/cmake/help/v3.11/policy/CMP0017.html
 project(healmex CXX)
 


### PR DESCRIPTION
There is a bug in the pkg-config module prior to CMake v3.12 which causes an error in resolving system libraries if a library search path was given in the package config. Require a version of CMake without the bug.