### PR TITLE
Upgrade to arguments blocks to more nicely handle keyword arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A package providing Matlab bindings to the [HEALPix][healpix] C++ package.
 ## Build Requirements
 
 - GCC 7+ (or a compiler which supports C++17's structured bindings)
-- Matlab R2018a+
+- Matlab R2019b+
 - CMake 3.9.0+
 - `pkg-config` (or `pkgconf`)
 - Internet connection (to download HEALPix sources)

--- a/matlab/+healmex/alm2cl.m.in
+++ b/matlab/+healmex/alm2cl.m.in
@@ -1,5 +1,5 @@
-function cl = alm2cl(alms1, alms2, varargin)
-% cl = alm2cl(alms1, alms2, varargin)
+function cl = alm2cl(alms1, alms2, opt)
+% cl = alm2cl(alms1, alms2, ...)
 %
 % Computes the angular power [cross-]spectrum from the set of harmonic
 % coefficients alms1 and alms2. If alms2 is empty, then alms1 is used to
@@ -20,18 +20,17 @@ function cl = alm2cl(alms1, alms2, varargin)
 %   cl          The angular power spectrum <alms1 x alms2*>.
 %
 
-  p = inputParser();
-  addParameter(p, 'lmax', [], @(x) isnumeric(x) & isscalar(x));
-  addParameter(p, 'mmax', [], @(x) isnumeric(x) & isscalar(x));
-  parse(p, varargin{:});
-  opt = p.Results;
-
-  [lmax, mmax] = @PACKAGEPREFIX@alm_getlmmax(alms, opt.lmax, opt.mmax);
-  if ~exist('alms2', 'var') || isempty(alms2)
-    alms2 = alms1;
+  arguments
+    alms1    (:,1) {mustBeNumeric}
+    alms2    (:,1) {mustBeNumeric} = alms1
+    opt.lmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
+    opt.mmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
   end
+
+  [lmax, mmax] = @PACKAGEPREFIX@alm_getlmmax(alms1, opt.lmax, opt.mmax);
   if numel(alms1) ~= numel(alms2)
-    error('Mismatched sizes in alms1 and alms2');
+    throwAsCaller(MException('healmex:alm2cl:dimensionMismatch', ...
+        'Mismatched sizes in alms1 and alms2'));
   end
 
   cl = libhealmex(int64(61), ...

--- a/matlab/+healmex/alm2map.m.in
+++ b/matlab/+healmex/alm2map.m.in
@@ -1,5 +1,5 @@
-function maps = alm2map(alms, nside, varargin)
-% maps = alm2map(alms, nside, varargin)
+function maps = alm2map(alms, nside, opt)
+% maps = alm2map(alms, nside, ...)
 %
 % INPUTS
 %   alms    The spherical harmonic coefficients of map. If map is Nx1, then
@@ -24,11 +24,12 @@ function maps = alm2map(alms, nside, varargin)
 %
 % EXAMPLE
 
-  p = inputParser();
-  addParameter(p, 'lmax', [], @(x) isnumeric(x) & isscalar(x));
-  addParameter(p, 'mmax', [], @(x) isnumeric(x) & isscalar(x));
-  parse(p, varargin{:});
-  opt = p.Results;
+  arguments
+    alms     (:,:) {mustBeNumeric}
+    nside    (1,1) {mustBeInteger,mustBeNonnegative}
+    opt.lmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
+    opt.mmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
+  end
 
   [lmax, mmax] = @PACKAGEPREFIX@alm_getlmmax(alms, opt.lmax, opt.mmax);
 
@@ -43,8 +44,8 @@ function maps = alm2map(alms, nside, varargin)
     almsG = complex(double(alms(:,2)));
     almsC = complex(double(alms(:,3)));
   else
-    error('alms: Expected size 1 or 3 in second dimension, got %d', ...
-        size(alms, 2));
+    throwAsCaller(MException('healmex:alm2map:dimensionMismatch', ...
+        'Expected alms to have size 1 or 3 in second dimension, got %d', size(alms, 2)));
   end
 
   [mapT, mapQ, mapU] = libhealmex(int64(55), ...

--- a/matlab/+healmex/alm2map_der1.m.in
+++ b/matlab/+healmex/alm2map_der1.m.in
@@ -1,5 +1,5 @@
-function maps = alm2map_der1(alms, nside, varargin)
-% maps = alm2map_der1(alms, nside, varargin)
+function maps = alm2map_der1(alms, nside, opt)
+% maps = alm2map_der1(alms, nside, ...)
 %
 % Synthesizes a map and its first derivatives from the provided alms at
 % Nisde = nside with RING ordered pixelization.
@@ -24,18 +24,14 @@ function maps = alm2map_der1(alms, nside, varargin)
 %
 % EXAMPLE
 
-  p = inputParser();
-  addParameter(p, 'lmax', [], @(x) isnumeric(x) & isscalar(x));
-  addParameter(p, 'mmax', [], @(x) isnumeric(x) & isscalar(x));
-  parse(p, varargin{:});
-  opt = p.Results;
+  arguments
+    alms     (:,1) {mustBeNumeric}
+    nside    (1,1) {mustBeInteger,mustBeNonnegative}
+    opt.lmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
+    opt.mmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
+  end
 
   [lmax, mmax] = @PACKAGEPREFIX@alm_getlmmax(alms, opt.lmax, opt.mmax);
-
-  if size(alms, 2) ~= 1
-    error('alm2map_der1: Expected alms to have size 1 in second dimension, got %d', ...
-        size(alms, 2));
-  end
 
   [map, mapdth, mapdph] = libhealmex(int64(56), ...
       int32(lmax), int32(mmax), complex(double(alms)), ...

--- a/matlab/+healmex/alm_getidx.m
+++ b/matlab/+healmex/alm_getidx.m
@@ -4,13 +4,11 @@ function idx = alm_getidx(lmax, l, m)
 % Returns the index of the alm coefficient (l,m) within a vector which includes
 % coefficients up to lmax.
 
-  if ~isscalar(lmax)
-    error('lmax must be a scalar');
+  arguments
+    lmax  (1,1) {mustBeInteger}
+    l     (:,:) {mustBeNumeric}
+    m     (:,:) {mustBeNumeric}
   end
-  m = m(:);
-  if length(m) > 1
-    l = l(:).';
-  end
+
   idx = m .* (2*lmax+1 - m) / 2 + l + 1;
-  idx = idx(:);
 end

--- a/matlab/+healmex/alm_getlmmax.m
+++ b/matlab/+healmex/alm_getlmmax.m
@@ -4,11 +4,10 @@ function [lmax, mmax] = alm_getlmmax(alms, lmax, mmax)
 % Infers the lmax and/or mmax from the alms vector (or length of the
 % first dimension if alms is a matrix).
 
-  if ~exist('lmax', 'var')
-    lmax = [];
-  end
-  if ~exist('mmax', 'var')
-    mmax = [];
+  arguments
+    alms (:,:)
+    lmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
+    mmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
   end
 
   if isempty(lmax)

--- a/matlab/+healmex/alm_getn.m
+++ b/matlab/+healmex/alm_getn.m
@@ -8,12 +8,9 @@ function nel=alm_getn(lmax, mmax)
 %   lmax    Must be a non-negative integer.
 %   mmax    Defaults to lmax. Must be in the range 0 to lmax.
 
-  if lmax < 0 || fix(lmax) ~= lmax
-    error('lmax must be a positive integer')
+  arguments
+    lmax {mustBeNonnegative}
+    mmax {mustBeNonnegative} = lmax
   end
-  if ~exist('mmax', 'var') || isempty(mmax)
-    mmax = lmax;
-  end
-
-  nel = ((mmax + 1) * (mmax + 2)) / 2 + (mmax + 1) * (lmax - mmax);
+  nel = ((mmax + 1) .* (mmax + 2)) / 2 + (mmax + 1) .* (lmax - mmax);
 end

--- a/matlab/+healmex/almxfl.m.in
+++ b/matlab/+healmex/almxfl.m.in
@@ -1,4 +1,4 @@
-function alms = almxfl(alms, fl, varargin)
+function alms = almxfl(alms, fl, opt)
 % alms = almxfl(alms, fl, varargin)
 %
 % Multiplies a set of alms by a vector fl.
@@ -18,11 +18,12 @@ function alms = almxfl(alms, fl, varargin)
 % OUTPUTS
 %   alms    Modified alms.
 
-  p = inputParser();
-  addParameter(p, 'lmax', [], @(x) isnumeric(x) & isscalar(x));
-  addParameter(p, 'mmax', [], @(x) isnumeric(x) & isscalar(x));
-  parse(p, varargin{:});
-  opt = p.Results;
+  arguments
+    alms     (:,:) {mustBeNumeric}
+    fl       (:,1) {mustBeNumeric}
+    opt.lmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
+    opt.mmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
+  end
 
   [lmax, mmax] = @PACKAGEPREFIX@alm_getlmmax(alms, opt.lmax, opt.mmax);
 

--- a/matlab/+healmex/ang2pix.m
+++ b/matlab/+healmex/ang2pix.m
@@ -1,11 +1,40 @@
-function ipix = ang2pix(nside, order, theta, phi)
-% ipix = ang2pix(nside, order, theta, phi)
+function ipix = ang2pix(nside, theta, phi, opt)
+% ipix = ang2pix(nside, theta, phi, ...)
 %
-% Calculates HEALPix pixel indices ipix (for an Nside = nside map with ordering
-% scheme order) which contain the spherical coordinate points (theta,phi),
-% where theta and phi are colatitude/azimuth angle in radians. order may be
-% 'RING' or 'NESTED'.
+% INPUTS
+%   nside       The HEALPix Nside parameter.
+%   theta       If lonlat==true, the latitude in degrees (-90 <= lat <= 90),
+%               otherwise the colatitude in radians (0 <= theta <= pi).
+%   phi         If lonlat==true, the longitude in degrees (0 <= lon < 360),
+%               otherwise the azimuth in radians (0 <= phi < 2*pi).
+%
+% KEY-VALUE PAIRS
+%   'lonlat'    Defaults to false. If true, instead returns the longitude and
+%               latitude coordinates [lon,lat] in degrees.
+%   'nest'      Defaults to false. If true, `ipix` are NESTED ordering pixels,
+%               otherwise assumes RING ordering.
+%
+% OUTPUT
+%   ipix        Pixel indices.
+%
 
+  arguments
+    nside       (1,1) {mustBeNumeric}
+    theta             {mustBeNumeric}
+    phi               {mustBeNumeric}
+    opt.lonlat  (1,1) logical = false
+    opt.nest    (1,1) logical = false
+  end
+
+  if opt.nest
+    order = 'NESTED';
+  else
+    order = 'RING';
+  end
+  if opt.lonlat
+    theta = deg2rad(90 - theta);
+    phi = deg2rad(phi);
+  end
   ipix = libhealmex(int64(16), ...
       int64(nside), char(order), double(theta), double(phi));
 end

--- a/matlab/+healmex/map2alm.m.in
+++ b/matlab/+healmex/map2alm.m.in
@@ -1,5 +1,5 @@
 function alms = map2alm(maps, varargin)
-% alms = map2alm(maps, varargin)
+% alms = map2alm(maps, ...)
 %
 % INPUTS
 %   maps    A vector (Nx1) or matrix (Nx3) of maps pixel values. Must be in
@@ -24,14 +24,13 @@ function alms = map2alm(maps, varargin)
 %           respectively, spin-2 transforms.
 %
 % EXAMPLE
-%
 
-  p = inputParser();
-  addParameter(p, 'lmax', [], @(x) isnumeric(x) & isscalar(x));
-  addParameter(p, 'mmax', [], @(x) isnumeric(x) & isscalar(x));
-  addParameter(p, 'iter',  3, @(x) isnumeric(x) & isscalar(x) & x >= 0);
-  parse(p, varargin{:});
-  opt = p.Results;
+  arguments
+    maps     (:,:) {mustBeNumeric}
+    opt.lmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
+    opt.mmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
+    opt.iter       {mustBeNumeric,mustBeScalarOrEmpty} = 3
+  end
 
   lmax = opt.lmax;
   mmax = opt.mmax;
@@ -59,8 +58,8 @@ function alms = map2alm(maps, varargin)
     mapQ = maps(:,2);
     mapU = maps(:,3);
   else
-    error('map2alm: Expected maps to have size 1 or 3 in second dimension, got %d', ...
-        size(maps, 2));
+    throwAsCaller(MException('healmex:map2alm:dimensionMismatch', ...
+        'Expected maps to have size 1 or 3 in second dimension, got %d', size(maps, 2)));
   end
 
   [almsT,almsG,almsC] = libhealmex(int64(53), ...

--- a/matlab/+healmex/pix2ang.m
+++ b/matlab/+healmex/pix2ang.m
@@ -1,5 +1,5 @@
-function [theta, phi] = pix2ang(nside, ipix, varargin)
-% [theta, phi] = pix2ang(nside, ipix, varargin)
+function [theta, phi] = pix2ang(nside, ipix, opt)
+% [theta, phi] = pix2ang(nside, ipix, ...)
 %
 % INPUTS
 %   nside       The HEALPix Nside parameter.
@@ -10,6 +10,7 @@ function [theta, phi] = pix2ang(nside, ipix, varargin)
 %               latitude coordinates [lon,lat] in degrees.
 %   'nest'      Defaults to false. If true, `ipix` are NESTED ordering pixels,
 %               otherwise assumes RING ordering.
+%
 % OUTPUT
 %   theta       If lonlat==true, the latitude in degrees (-90 <= lat <= 90),
 %               otherwise the colatitude in radians (0 <= theta <= pi).
@@ -19,11 +20,12 @@ function [theta, phi] = pix2ang(nside, ipix, varargin)
 % EXAMPLE
 %   [lon,lat] = healmex.pix2ang(512, (1000:2000)', 'lonlat', true);
 
-  p = inputParser();
-  addParameter(p, 'nest', false, @islogical);
-  addParameter(p, 'lonlat', false, @islogical);
-  parse(p, varargin{:});
-  opt = p.Results;
+  arguments
+    nside       (1,1) {mustBeNumeric}
+    ipix              {mustBeNumeric}
+    opt.lonlat  (1,1) logical = false
+    opt.nest    (1,1) logical = false
+  end
 
   if opt.nest
     order = 'NESTED';

--- a/matlab/+healmex/pix2vec.m
+++ b/matlab/+healmex/pix2vec.m
@@ -1,5 +1,5 @@
-function [x, y, z] = pix2vec(nside, ipix, varargin)
-% [x, y, z] = pix2vec(nside, ipix, varargin)
+function [x, y, z] = pix2vec(nside, ipix, opt)
+% [x, y, z] = pix2vec(nside, ipix, ...)
 %
 % INPUTS
 %   nside       The HEALPix Nside parameter.
@@ -17,10 +17,11 @@ function [x, y, z] = pix2vec(nside, ipix, varargin)
 % EXAMPLE
 %   [x, y, z] = healmex.pix2vec(512, 0:4*512-1);
 
-  p = inputParser();
-  addParameter(p, 'nest', false, @islogical);
-  parse(p, varargin{:});
-  opt = p.Results;
+  arguments
+    nside     (1,1) {mustBeNumeric}
+    ipix            {mustBeNumeric}
+    opt.nest  (1,1) logical = false
+  end
 
   if opt.nest
     order = 'NESTED';

--- a/matlab/+healmex/pix2xyf.m
+++ b/matlab/+healmex/pix2xyf.m
@@ -1,5 +1,5 @@
-function [x, y, f] = pix2xyf(nside, ipix, varargin)
-% [x, y, f] = pix2xyf(nside, ipix, varargin)
+function [x, y, f] = pix2xyf(nside, ipix, opt)
+% [x, y, f] = pix2xyf(nside, ipix, ...)
 %
 % INPUTS
 %   nside       The HEALPix Nside parameter.
@@ -17,10 +17,11 @@ function [x, y, f] = pix2xyf(nside, ipix, varargin)
 % EXAMPLE
 %   [x, y, f] = healmex.pix2xyf(512, (1000:2000)');
 
-  p = inputParser();
-  addParameter(p, 'nest', false, @islogical);
-  parse(p, varargin{:});
-  opt = p.Results;
+  arguments
+    nside     (1,1) {mustBeNumeric}
+    ipix            {mustBeNumeric}
+    opt.nest  (1,1) logical = false
+  end
 
   if opt.nest
     order = 'NESTED';

--- a/matlab/+healmex/pix2zphi.m
+++ b/matlab/+healmex/pix2zphi.m
@@ -1,5 +1,5 @@
-function [z, phi] = pix2zphi(nside, ipix, varargin)
-% [z, phi] = pix2zphi(nside, ipix, varargin)
+function [z, phi] = pix2zphi(nside, ipix, opt)
+% [z, phi] = pix2zphi(nside, ipix, ...)
 %
 % INPUTS
 %   nside       The HEALPix Nside parameter.
@@ -16,10 +16,11 @@ function [z, phi] = pix2zphi(nside, ipix, varargin)
 % EXAMPLE
 %   [z, phi] = healmex.pix2zphi(512, (1000:2000)');
 
-  p = inputParser();
-  addParameter(p, 'nest', false, @islogical);
-  parse(p, varargin{:});
-  opt = p.Results;
+  arguments
+    nside     (1,1) {mustBeNumeric}
+    ipix            {mustBeNumeric}
+    opt.nest  (1,1) logical = false
+  end
 
   if opt.nest
     order = 'NESTED';

--- a/matlab/+healmex/rotate_alm.m.in
+++ b/matlab/+healmex/rotate_alm.m.in
@@ -1,5 +1,5 @@
-function alms = rotate_alm(alms, rotate, varargin)
-% alms = rotate_alms(alms, rotate, varargin)
+function alms = rotate_alm(alms, rotate, opt)
+% alms = rotate_alms(alms, rotate, ...)
 % INPUTS
 %   alms        A Nx1 or Nx3 complex matrix of spherical harmonic coefficients.
 %
@@ -43,11 +43,12 @@ function alms = rotate_alm(alms, rotate, varargin)
 %
 % EXAMPLE
 
-  p = inputParser();
-  addParameter(p, 'lmax', [], @(x) isnumeric(x) & isscalar(x));
-  addParameter(p, 'mmax', [], @(x) isnumeric(x) & isscalar(x));
-  parse(p, varargin{:});
-  opt = p.Results;
+  arguments
+    alms     (:,:) {mustBeNumeric}
+    rotate
+    opt.lmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
+    opt.mmax       {mustBeNumeric,mustBeScalarOrEmpty} = []
+  end
 
   [lmax, mmax] = @PACKAGEPREFIX@alm_getlmmax(alms, opt.lmax, opt.mmax);
 
@@ -62,8 +63,8 @@ function alms = rotate_alm(alms, rotate, varargin)
     almsG = complex(double(alms(:,2)));
     almsC = complex(double(alms(:,3)));
   else
-    error('rotate_alms: Expected alms to have size 1 or 3 in second dimension, got %d', ...
-        size(alms, 2));
+    throwAsCaller(MException('healmex:rotate_alm:dimensionMismatch', ...
+        'Expected alms to have size 1 or 3 in second dimension, got %d', size(alms, 2)));
   end
 
   % Rotate by coordinate transformation name

--- a/matlab/+healmex/vec2pix.m
+++ b/matlab/+healmex/vec2pix.m
@@ -1,5 +1,5 @@
-function ipix = vec2pix(nside, x, y, z, varargin)
-% ipix = vec2pix(nside, order, x, y, z, varargin)
+function ipix = vec2pix(nside, x, y, z, opt)
+% ipix = vec2pix(nside, x, y, z, ...)
 %
 % INPUTS
 %   nside       The HEALPix Nside parameter.
@@ -18,10 +18,13 @@ function ipix = vec2pix(nside, x, y, z, varargin)
 %   [x, y, z] = sph2cart(0.0:0.1:pi/2, 0.0:0.05:pi/4, 1);
 %   ipix = healmex.pix2vec(512, x, y, z);
 
-  p = inputParser();
-  addParameter(p, 'nest', false, @islogical);
-  parse(p, varargin{:});
-  opt = p.Results;
+  arguments
+    nside    (1,1) {mustBeNumeric}
+    x              {mustBeNumeric}
+    y              {mustBeNumeric}
+    z              {mustBeNumeric}
+    opt.nest (1,1) logical = false
+  end
 
   if opt.nest
     order = 'NESTED';

--- a/matlab/+healmex/xyf2pix.m
+++ b/matlab/+healmex/xyf2pix.m
@@ -1,5 +1,5 @@
-function ipix = xyf2pix(nside, x, y, f, varargin)
-% ipix = xyf2pix(nside, x, y, f, varargin)
+function ipix = xyf2pix(nside, x, y, f, opt)
+% ipix = xyf2pix(nside, x, y, f, ...)
 %
 % INPUTS
 %   nside       The HEALPix Nside parameter.
@@ -17,10 +17,13 @@ function ipix = xyf2pix(nside, x, y, f, varargin)
 % EXAMPLE
 %   ipix = healmex.pix2xyf(512, x, y, f);
 
-  p = inputParser();
-  addParameter(p, 'nest', false, @islogical);
-  parse(p, varargin{:});
-  opt = p.Results;
+  arguments
+    nside    (1,1) {mustBeNumeric}
+    x              {mustBeNumeric}
+    y              {mustBeNumeric}
+    f              {mustBeNumeric}
+    opt.nest (1,1) logical = false
+  end
 
   if opt.nest
     order = 'NESTED';

--- a/matlab/+healmex/zphi2pix.m
+++ b/matlab/+healmex/zphi2pix.m
@@ -1,11 +1,32 @@
-function ipix = zphi2pix(nside, order, z, phi)
-% ipix = zphi2pix(nside, order, z, phi)
+function ipix = zphi2pix(nside, z, phi, opt)
+% ipix = zphi2pix(nside, z, phi, ...)
 %
-% Calculates HEALPix pixel indices ipix (for an Nside = nside map with ordering
-% scheme order) which contain the coordinate points (z, phi), where z is a
-% Cartesian coordinate and phi is the azimuth angle in radians. order may be
-% 'RING' or 'NESTED'.
+% INPUTS
+%   nside       The HEALPix Nside parameter.
+%   z           The cosine of the colatitude (-1 <= z <= 1).
+%   phi         The azimuth phi in radians (0 <= phi < 2*pi).
+%
+% KEY-VALUE PAIRS
+%   'nest'      Defaults to false. If true, `ipix` are NESTED ordering pixels,
+%               otherwise assumes RING ordering.
+%
+% OUTPUT
+%   ipix        Pixel indices.
+%
+% EXMAPLE
 
+  arguments
+    nside     (1,1) {mustBeNumeric}
+    z               {mustBeNumeric}
+    phi             {mustBeNumeric}
+    opt.nest  (1,1) logical = false
+  end
+
+  if opt.nest
+    order = 'NESTED';
+  else
+    order = 'RING';
+  end
   ipix = libhealmex(int64(15), ...
       int64(nside), char(order), double(z), double(phi));
 end


### PR DESCRIPTION
A new feature in R2019b are [`arguments` blocks](https://www.mathworks.com/help/matlab/input-and-output-arguments.html) which make handling keyword argument calling conventions easier in Matlab. In particular, [R2021a introduces](https://www.mathworks.com/help/matlab/matlab_prog/function-argument-validation-1.html#mw_1b62b6d6-a445-4c55-a9b9-9c70becfdbe6) traditional keyword argument calling syntax (i.e. `key = value`) into the Matlab syntax.

Use this new syntax to simplify argument parsing.